### PR TITLE
[hotfix][docs] Fix type error in example for kubernetes.operator.savepoint.history.max.count

### DIFF
--- a/docs/content/docs/custom-resource/job-management.md
+++ b/docs/content/docs/custom-resource/job-management.md
@@ -206,7 +206,7 @@ Users can control the cleanup behaviour by specifying a maximum age and maximum 
 
 ```
 kubernetes.operator.savepoint.history.max.age: 24 h
-kubernetes.operator.savepoint.history.max.count: 5
+kubernetes.operator.savepoint.history.max.count: "5"
 ```
 
 {{< hint info >}}

--- a/docs/content/docs/custom-resource/job-management.md
+++ b/docs/content/docs/custom-resource/job-management.md
@@ -266,7 +266,7 @@ If a new upgrade is not marked stable within a certain configurable time period 
 
 To enable rollbacks you need to set:
 ```
-kubernetes.operator.deployment.rollback.enabled: true
+kubernetes.operator.deployment.rollback.enabled: "true"
 ```
 
 HA is currently required for the rollback functionality.


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

In the [documentation](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/custom-resource/job-management/#savepoint-history) the example illustrates an integer being passed for `kubernetes.operator.savepoint.history.max.coun`.  The type system requires a string.

You get an error message like this:

```
# flinkdeployments.flink.apache.org "basic-checkpoint-ha-example" was not valid:
# * spec.flinkConfiguration.kubernetes.operator.savepoint.history.max.count: Invalid value: "integer": spec.flinkConfiguration.kubernetes.operator.savepoint.history.max.count in body must be of type string: "i
```

I think the documentation is in error, so I submit a PR to fix it.
